### PR TITLE
fix: call set context ante handler first

### DIFF
--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -33,6 +33,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	}
 
 	anteDecorators := []sdk.AnteDecorator{
+		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		ante.NewRejectExtensionOptionsDecorator(),
 		ante.NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),


### PR DESCRIPTION
Refs: Agoric/agoric-sdk#5769

Add missing ante handler which was causing gas calculation to accumulate across the entire block.