### PR TITLE
fix: fix upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -710,7 +710,7 @@ func NewGaiaApp(
 
 	if upgradeInfo.Name == upgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := store.StoreUpgrades{
-			Added: []string{icahosttypes.StoreKey},
+			Added: []string{icacontrollertypes.StoreKey, icahosttypes.StoreKey},
 		}
 
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
The upgrade handler in gaia 7.0.2 is broken, and results in a panic for folks with custom pruning settings.

discussion: https://github.com/cosmos/ibc-go/issues/1088